### PR TITLE
Get the email verification url from base config

### DIFF
--- a/{{ cookiecutter.project_slug }}/.env.template
+++ b/{{ cookiecutter.project_slug }}/.env.template
@@ -52,6 +52,9 @@
 # This is used for forming the password reset
 {{ cookiecutter.project_slug | upper() }}_PASSWORD_RESET_URL=http://localhost:3000/
 
+# This is used for forming the email verification url
+{{ cookiecutter.project_slug | upper() }}_EMAIL_VERIFICATION_URLL=http://localhost:3000/
+
 # The number of results on a single page
 {{ cookiecutter.project_slug | upper() }}_MAX_PAGE_SIZE=20
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/accounts/allauth_adapter.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/accounts/allauth_adapter.py
@@ -1,0 +1,25 @@
+from allauth.account.adapter import DefaultAccountAdapter
+from django.conf import settings
+
+
+class CustomAllauthAdapter(DefaultAccountAdapter):
+    def _get_verification_url(self):
+        set_url = getattr(settings, "EMAIL_VERIFICATION_URL")
+        if not set_url:
+            return None
+        if set_url[-1] != "/":
+            return set_url + "/"
+        return set_url
+
+    def send_mail(self, template_prefix, email, context):
+        verification_url = self._get_verification_url()
+        if verification_url:
+            context[
+                "activate_url"
+            ] = f"{verification_url()}{context['key']}"
+        else:
+            return super(CustomAllauthAdapter, self).send_mail(
+                template_prefix, email, context
+            )
+        msg = self.render_mail(template_prefix, email, context)
+        msg.send()

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/config/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/config/base.py
@@ -305,6 +305,15 @@ class Common(Configuration):
         "http://localhost:3000/",
     )
 
+    # Frontend URL to be used for email verification
+    EMAIL_VERIFICATION_URL = env.str(
+        "{{ cookiecutter.project_slug | upper() }}_EMAIL_VERIFICATION_URL",
+        None
+    )
+
+    # Override the account adapter to use the custom one
+    ACCOUNT_ADAPTER = "{{ cookiecutter.project_slug }}.apps.accounts.allauth_adapter.CustomAllauthAdapter"
+
     # Mandate the need for an Email Address when registering.
     ACCOUNT_EMAIL_REQUIRED = True
 


### PR DESCRIPTION
Towards #3 

Overrides the allauth adapter and adds the corresponding options in `base.py` and `.env.template`